### PR TITLE
Refactor treaty contracts

### DIFF
--- a/contracts/interfaces/ITreaty.sol
+++ b/contracts/interfaces/ITreaty.sol
@@ -1,8 +1,0 @@
-//SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
-
-interface ITreaty {
-    function diamond() external view returns (address);
-
-    function name() external view returns (string memory);
-}

--- a/contracts/standards/CurioTreaty.sol
+++ b/contracts/standards/CurioTreaty.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import {AdminFacet} from "contracts/facets/AdminFacet.sol";
 import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 
 abstract contract CurioTreaty {
@@ -42,13 +43,13 @@ abstract contract CurioTreaty {
      * @dev Check if a nation has been a treaty signer for at least a duration.
      * @param _duration duration in seconds
      */
-    function minimumStay(uint256 _duration) public view returns (bool) {
+    modifier minimumStay(uint256 _duration) {
         GetterFacet getter = GetterFacet(diamond);
         uint256 nationID = getter.getEntityByAddress(msg.sender);
         uint256 treatyID = getter.getEntityByAddress(address(this));
 
         // Check if nation has been a treaty signer for at least the duration
-        uint256 nationJoinTime = abi.decode(getter.getComponent("InitTimestamp").getBytesValue(getter.getNationTreatySignature(nationId, treatyID)), (uint256));
+        uint256 nationJoinTime = abi.decode(getter.getComponent("InitTimestamp").getBytesValue(getter.getNationTreatySignature(nationID, treatyID)), (uint256));
         require(block.timestamp >= nationJoinTime + _duration, "Have not stayed for minimum duration");
         _;
     }

--- a/contracts/standards/CurioTreaty.sol
+++ b/contracts/standards/CurioTreaty.sol
@@ -1,29 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {ITreaty} from "contracts/interfaces/ITreaty.sol";
-import {GameFacet} from "contracts/facets/GameFacet.sol";
 import {GetterFacet} from "contracts/facets/GetterFacet.sol";
-import {AdminFacet} from "contracts/facets/AdminFacet.sol";
 
-abstract contract CurioTreaty is ITreaty {
+abstract contract CurioTreaty {
     // Facets
     address public diamond;
-    GameFacet public game;
-    GetterFacet public getter;
-    AdminFacet public admin;
-
-    // Treaty data
-    string public name;
-    string public description;
 
     constructor(address _diamond) {
         require(_diamond != address(0), "CurioTreaty: Diamond address required");
-
         diamond = _diamond;
-        game = GameFacet(_diamond);
-        getter = GetterFacet(_diamond);
-        admin = AdminFacet(_diamond);
     }
 
     modifier onlyGame() {
@@ -32,6 +18,7 @@ abstract contract CurioTreaty is ITreaty {
     }
 
     modifier onlyOwner() {
+        GetterFacet getter = GetterFacet(diamond);
         uint256 treatyID = getter.getEntityByAddress(address(this));
         uint256 ownerID = abi.decode(getter.getComponent("Owner").getBytesValue(treatyID), (uint256));
         require(ownerID == getter.getEntityByAddress(msg.sender), "CurioTreaty: Only owner can call");
@@ -39,25 +26,51 @@ abstract contract CurioTreaty is ITreaty {
     }
 
     modifier onlySigner() {
+        GetterFacet getter = GetterFacet(diamond);
         require(getter.getNationTreatySignature(getter.getEntityByAddress(msg.sender), getter.getEntityByAddress(address(this))) != 0, "CurioTreaty: Only signer can call");
         _;
     }
 
     /// @dev No need to use if the treaty does not need whitelist
     modifier onlyWhitelist() {
+        GetterFacet getter = GetterFacet(diamond);
         require(getter.isWhitelistedByTreaty(getter.getEntityByAddress(msg.sender), getter.getEntityByAddress(address(this))), "CurioTreaty: Only whitelisted nations can call");
         _;
     }
 
+    /**
+     * @dev Check if a nation has been a treaty signer for at least a duration.
+     * @param _duration duration in seconds
+     */
+    function minimumStay(uint256 _duration) public view returns (bool) {
+        GetterFacet getter = GetterFacet(diamond);
+        uint256 nationID = getter.getEntityByAddress(msg.sender);
+        uint256 treatyID = getter.getEntityByAddress(address(this));
+
+        // Check if nation has been a treaty signer for at least the duration
+        uint256 nationJoinTime = abi.decode(getter.getComponent("InitTimestamp").getBytesValue(getter.getNationTreatySignature(nationId, treatyID)), (uint256));
+        require(block.timestamp >= nationJoinTime + _duration, "Have not stayed for minimum duration");
+        _;
+    }
+
+    // ----------------------------------------------------------
+    // TREATY INFO (CALLED BY NATION)
+    // ----------------------------------------------------------
+
+    function name() external view virtual returns (string memory);
+    function description() external view virtual returns (string memory);
+
     // ----------------------------------------------------------
     // MEMBERSHIP FUNCTIONS (CALLED BY NATION)
     // ----------------------------------------------------------
-
+    
     /**
      * @dev Join treaty. Must be called by nation.
      */
     function treatyJoin() public virtual {
         // Add signature
+        GetterFacet getter = GetterFacet(diamond);
+        AdminFacet admin = AdminFacet(diamond);
         uint256 nationID = getter.getEntityByAddress(msg.sender);
         admin.addSigner(nationID);
     }
@@ -67,6 +80,8 @@ abstract contract CurioTreaty is ITreaty {
      */
     function treatyLeave() public virtual {
         // Remove signature
+        GetterFacet getter = GetterFacet(diamond);
+        AdminFacet admin = AdminFacet(diamond);
         uint256 nationID = getter.getEntityByAddress(msg.sender);
         admin.removeSigner(nationID);
     }
@@ -82,26 +97,10 @@ abstract contract CurioTreaty is ITreaty {
         uint256 _subjectID,
         bool _canCall
     ) public virtual {
+        GetterFacet getter = GetterFacet(diamond);
+        AdminFacet admin = AdminFacet(diamond);
         uint256 nationID = getter.getEntityByAddress(msg.sender);
         admin.adminDelegateGameFunction(nationID, _functionName, getter.getEntityByAddress(address(this)), _subjectID, _canCall);
-    }
-
-    // ----------------------------------------------------------
-    // HELPERS
-    // ----------------------------------------------------------
-
-    /**
-     * @dev Check if a nation has been a treaty signer for at least a duration.
-     * @param _nationID ID of the nation
-     * @param _duration duration in seconds
-     * @return true if the nation has been a treaty signer for at least the duration
-     */
-    function minimumStayCheck(uint256 _nationID, uint256 _duration) public view returns (bool) {
-        uint256 treatyID = getter.getEntityByAddress(address(this));
-
-        // Check if nation has been a treaty signer for at least the duration
-        uint256 nationJoinTime = abi.decode(getter.getComponent("InitTimestamp").getBytesValue(getter.getNationTreatySignature(_nationID, treatyID)), (uint256));
-        return block.timestamp >= nationJoinTime + _duration;
     }
 
     // ----------------------------------------------------------

--- a/contracts/treaties/Alliance.sol
+++ b/contracts/treaties/Alliance.sol
@@ -1,18 +1,26 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {CurioTreaty} from "contracts/standards/CurioTreaty.sol";
 import {CurioERC20} from "contracts/standards/CurioERC20.sol";
+import {CurioTreaty} from "contracts/standards/CurioTreaty.sol";
+import {GameFacet} from "contracts/facets/GameFacet.sol";
+import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 import {Position} from "contracts/libraries/Types.sol";
 
 contract Alliance is CurioTreaty {
     CurioERC20 public goldToken;
 
     constructor(address _diamond) CurioTreaty(_diamond) {
+        GetterFacet getter = GetterFacet(diamond);
         goldToken = getter.getTokenContract("Gold");
+    }
 
-        name = "Alliance";
-        description = "A treaty between two or more countries to work together towards a common goal or to defend each other in the case of external aggression";
+    function name() external view override returns (string memory) {
+        return "Alliance";
+    }
+
+    function description() external view override returns (string memory) {
+        return "A treaty between two or more countries to work together towards a common goal or to defend each other in the case of external aggression";
     }
 
     // ----------------------------------------------------------
@@ -20,6 +28,8 @@ contract Alliance is CurioTreaty {
     // ----------------------------------------------------------
 
     function treatyJoin() public override {
+        GetterFacet getter = GetterFacet(diamond);
+
         // Transfer 1000 gold from nation to treaty
         address nationCapitalAddress = getter.getAddress(getter.getCapital(getter.getEntityByAddress(msg.sender)));
         goldToken.transferFrom(nationCapitalAddress, address(this), 1000);
@@ -30,12 +40,11 @@ contract Alliance is CurioTreaty {
         super.treatyJoin();
     }
 
-    function treatyLeave() public override {
-        // Check if nation has stayed in alliance for at least 10 seconds
-        uint256 nationID = getter.getEntityByAddress(msg.sender);
-        require(minimumStayCheck(nationID, 10), "Alliance: Nation must stay for at least 10 seconds");
-
+    function treatyLeave() public override minimumStay(10) {
+        GetterFacet getter = GetterFacet(diamond);
+      
         // Transfer 1000 gold from treaty back to nation
+        uint256 nationID = getter.getEntityByAddress(msg.sender);
         address nationCapitalAddress = getter.getAddress(getter.getCapital(nationID));
         goldToken.transfer(nationCapitalAddress, 1000);
 
@@ -50,6 +59,8 @@ contract Alliance is CurioTreaty {
      * @param _targetArmyID target army entity
      */
     function treatyBesiege(uint256 _targetArmyID) public onlySigner {
+        GetterFacet getter = GetterFacet(diamond);
+     
         // Check if target army is in a non-ally nation
         uint256 targetNationID = getter.getNation(_targetArmyID);
         uint256 treatyID = getter.getEntityByAddress(address(this));
@@ -67,7 +78,7 @@ contract Alliance is CurioTreaty {
                 uint256 armyNationID = getter.getNation(armyIDs[j]);
                 if (getter.getNationTreatySignature(armyNationID, treatyID) != 0) {
                     // Use army to battle target army
-                    game.battle(armyIDs[j], _targetArmyID);
+                    GameFacet(diamond).battle(armyIDs[j], _targetArmyID);
 
                     // Return early if target army is dead
                     if (getter.getNation(_targetArmyID) == 0) return;
@@ -81,6 +92,8 @@ contract Alliance is CurioTreaty {
     // ----------------------------------------------------------
 
     function approveBattle(uint256 _nationID, bytes memory _encodedParams) public view override returns (bool) {
+        GetterFacet getter = GetterFacet(diamond);
+
         // Disapprove if target nation is an ally
         (, , uint256 targetID) = abi.decode(_encodedParams, (uint256, uint256, uint256));
         uint256 targetNationID = getter.getNation(targetID);

--- a/contracts/treaties/Alliance.sol
+++ b/contracts/treaties/Alliance.sol
@@ -15,11 +15,11 @@ contract Alliance is CurioTreaty {
         goldToken = getter.getTokenContract("Gold");
     }
 
-    function name() external view override returns (string memory) {
+    function name() external pure override returns (string memory) {
         return "Alliance";
     }
 
-    function description() external view override returns (string memory) {
+    function description() external pure override returns (string memory) {
         return "A treaty between two or more countries to work together towards a common goal or to defend each other in the case of external aggression";
     }
 

--- a/contracts/treaties/CollectiveDefenseFund.sol
+++ b/contracts/treaties/CollectiveDefenseFund.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.13;
 
 import {CurioTreaty} from "contracts/standards/CurioTreaty.sol";
-import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 import {CurioERC20} from "contracts/standards/CurioERC20.sol";
+import {GetterFacet} from "contracts/facets/GetterFacet.sol";
+import {AdminFacet} from "contracts/facets/AdminFacet.sol";
 import {Position} from "contracts/libraries/Types.sol";
 import {Set} from "contracts/Set.sol";
 
@@ -24,6 +25,7 @@ contract CollectiveDefenseFund is CurioTreaty {
     Set public council;
 
     modifier onlyCouncilOrPact() {
+        GetterFacet getter = GetterFacet(diamond);
         uint256 callerID = getter.getEntityByAddress(msg.sender);
         require(council.includes(callerID) || msg.sender == address(this), "CDFund: Only council or pact can call");
         _;
@@ -31,8 +33,7 @@ contract CollectiveDefenseFund is CurioTreaty {
 
     constructor(address _diamond) CurioTreaty(_diamond) {
         // Initialize treaty
-        name = "Collective Defense Fund";
-        description = "Owner of the League can point to which nation the league is sanctioning";
+        GetterFacet getter = GetterFacet(diamond);
         goldToken = getter.getTokenContract("Gold");
         foodToken = getter.getTokenContract("Food");
 
@@ -40,19 +41,30 @@ contract CollectiveDefenseFund is CurioTreaty {
         council = new Set();
     }
 
+    function name() external view override returns (string memory) {
+        return "Collective Defense Fund";
+    }
+
+    function description() external view override returns (string memory) {
+        return "Owner of the League can point to which nation the league is sanctioning";
+    }
+
     // ----------------------------------------------------------
     // Owner and council functions
     // ----------------------------------------------------------
 
     function addToWhitelist(uint256 _nationID) public onlyOwner {
+        AdminFacet admin = AdminFacet(diamond);
         admin.addToTreatyWhitelist(_nationID);
     }
 
     function removeFromWhitelist(uint256 _nationID) public onlyOwner {
+        AdminFacet admin = AdminFacet(diamond);
         admin.removeFromTreatyWhitelist(_nationID);
     }
 
     function addToCouncil(uint256 _nationID) public onlyOwner {
+        GetterFacet getter = GetterFacet(diamond);
         require(getter.getNationTreatySignature(_nationID, getter.getEntityByAddress(address(this))) != 0, "CDFund: Only signed nations can join council");
         council.add(_nationID);
     }
@@ -70,6 +82,8 @@ contract CollectiveDefenseFund is CurioTreaty {
     }
 
     function removeMember(uint256 _nationID) public onlyCouncilOrPact {
+        GetterFacet getter = GetterFacet(diamond);
+       
         // Only owner can remove council members
         uint256 treatyID = getter.getEntityByAddress(address(this));
         uint256 ownerID = abi.decode(getter.getComponent("Owner").getBytesValue(treatyID), (uint256));
@@ -79,11 +93,14 @@ contract CollectiveDefenseFund is CurioTreaty {
             require(!council.includes(_nationID), "CDFund: Need owner to `removeFromCouncil` first");
         }
 
+        AdminFacet admin = AdminFacet(diamond);
         admin.removeFromTreatyWhitelist(_nationID); // need to be whitelisted again for joining
         admin.removeSigner(_nationID);
     }
 
     function withdraw(uint256 _goldAmount, uint256 _foodAmount) external onlyCouncilOrPact {
+        GetterFacet getter = GetterFacet(diamond);
+      
         // Check that withdrawal amount is within quota
         require(_goldAmount <= goldWithdrawQuota, "CDFund: Amount exceeds quota");
         require(_foodAmount <= foodWithdrawQuota, "CDFund: Amount exceeds quota");
@@ -104,6 +121,7 @@ contract CollectiveDefenseFund is CurioTreaty {
     }
 
     function removeAllOverdueMembers() external onlyCouncilOrPact {
+        GetterFacet getter = GetterFacet(diamond);
         uint256 treatyID = getter.getEntityByAddress(address(this));
         uint256[] memory signers = getter.getTreatySigners(treatyID);
 
@@ -120,6 +138,8 @@ contract CollectiveDefenseFund is CurioTreaty {
         string memory _resourceType,
         uint256 _amount
     ) external onlyCouncilOrPact {
+        GetterFacet getter = GetterFacet(diamond);
+    
         // Check that withdrawal amount is within quota
         if (_strEq(_resourceType, "Gold")) {
             require(_amount <= goldWithdrawQuota, "CDFund: Amount exceeds quota");
@@ -143,6 +163,8 @@ contract CollectiveDefenseFund is CurioTreaty {
     // ----------------------------------------------------------
 
     function treatyJoin() public override onlyWhitelist {
+        GetterFacet getter = GetterFacet(diamond);
+       
         // Check whether the nation is whitelisted
         uint256 nationID = getter.getEntityByAddress(msg.sender);
         uint256 treatyID = getter.getEntityByAddress(address(this));
@@ -156,6 +178,8 @@ contract CollectiveDefenseFund is CurioTreaty {
     }
 
     function treatyLeave() public override {
+        GetterFacet getter = GetterFacet(diamond);
+       
         // Check if nation has stayed in pact for at least 10 seconds
         uint256 nationID = getter.getEntityByAddress(msg.sender);
         uint256 treatyID = getter.getEntityByAddress(address(this));
@@ -166,6 +190,7 @@ contract CollectiveDefenseFund is CurioTreaty {
         council.remove(nationID);
 
         // Remove nation from whitelist
+        AdminFacet admin = AdminFacet(diamond);
         admin.removeFromTreatyWhitelist(nationID); // need to be whitelisted again to join
 
         // Remove nation's signature
@@ -174,6 +199,8 @@ contract CollectiveDefenseFund is CurioTreaty {
 
     /// @notice Can pay between half and full deposit interval
     function payMembershipFee() external onlySigner {
+        GetterFacet getter = GetterFacet(diamond);
+        
         // Check last paid time
         uint256 nationID = getter.getEntityByAddress(msg.sender);
         require(block.timestamp > lastPaid[nationID] + depositTimeInterval / 2, "CDFund: Last payment was too soon");
@@ -182,6 +209,7 @@ contract CollectiveDefenseFund is CurioTreaty {
     }
 
     function _payFeesHelper(uint256 _nationID) internal {
+        GetterFacet getter = GetterFacet(diamond);
         address senderCapitalAddr = getter.getAddress(getter.getCapital(_nationID));
 
         // Check balance sufficience
@@ -201,6 +229,8 @@ contract CollectiveDefenseFund is CurioTreaty {
     // ----------------------------------------------------------
 
     function approveBattle(uint256 _nationID, bytes memory _encodedParams) public view override returns (bool) {
+        GetterFacet getter = GetterFacet(diamond);
+       
         // Disapprove if target nation is part of collective fund
         (, , uint256 battleTargetID) = abi.decode(_encodedParams, (uint256, uint256, uint256));
         uint256 targetNationID = getter.getNation(battleTargetID);

--- a/contracts/treaties/CollectiveDefenseFund.sol
+++ b/contracts/treaties/CollectiveDefenseFund.sol
@@ -41,11 +41,11 @@ contract CollectiveDefenseFund is CurioTreaty {
         council = new Set();
     }
 
-    function name() external view override returns (string memory) {
+    function name() external pure override returns (string memory) {
         return "Collective Defense Fund";
     }
 
-    function description() external view override returns (string memory) {
+    function description() external pure override returns (string memory) {
         return "Owner of the League can point to which nation the league is sanctioning";
     }
 

--- a/contracts/treaties/Embargo.sol
+++ b/contracts/treaties/Embargo.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.13;
 
 import {CurioTreaty} from "contracts/standards/CurioTreaty.sol";
-import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 import {CurioERC20} from "contracts/standards/CurioERC20.sol";
+import {GetterFacet} from "contracts/facets/GetterFacet.sol";
+import {AdminFacet} from "contracts/facets/AdminFacet.sol";
 import {Position} from "contracts/libraries/Types.sol";
 import {Set} from "contracts/Set.sol";
 
@@ -11,9 +12,15 @@ contract Embargo is CurioTreaty {
     Set public sanctionList;
 
     constructor(address _diamond) CurioTreaty(_diamond) {
-        name = "Embargo";
-        description = "Owner of the League can point to which nation the league is sanctioning";
         sanctionList = new Set();
+    }
+
+    function name() external view override returns (string memory) {
+        return "Embargo";
+    }
+
+    function description() external view override returns (string memory) {
+        return "Owner of the League can point to which nation the league is sanctioning";
     }
 
     // ----------------------------------------------------------
@@ -28,6 +35,7 @@ contract Embargo is CurioTreaty {
     }
 
     function removeMember(uint256 _nationID) public onlyOwner {
+        AdminFacet admin = AdminFacet(diamond);
         admin.removeFromTreatyWhitelist(_nationID); // need to be whitelisted again for joining
         admin.removeSigner(_nationID);
     }
@@ -35,11 +43,7 @@ contract Embargo is CurioTreaty {
     // ----------------------------------------------------------
     // Player functions
     // ----------------------------------------------------------
-    function treatyLeave() public override {
-        // Check if nation has stayed in pact for at least 30 seconds
-        uint256 nationID = getter.getEntityByAddress(msg.sender);
-        require(minimumStayCheck(nationID, 30), "NAPact: Nation must stay for at least 30 seconds");
-
+    function treatyLeave() public override minimumStay(30) {
         super.treatyLeave();
     }
 
@@ -48,6 +52,8 @@ contract Embargo is CurioTreaty {
     // ----------------------------------------------------------
 
     function approveTransfer(uint256 _nationID, bytes memory _encodedParams) public view override returns (bool) {
+        GetterFacet getter = GetterFacet(diamond);
+       
         // Disapprove if transfer is to a nation on the sanction list
         (uint256 toID, ) = abi.decode(_encodedParams, (uint256, uint256));
         uint256 toNationID = getter.getNation(toID);

--- a/contracts/treaties/Embargo.sol
+++ b/contracts/treaties/Embargo.sol
@@ -15,11 +15,11 @@ contract Embargo is CurioTreaty {
         sanctionList = new Set();
     }
 
-    function name() external view override returns (string memory) {
+    function name() external pure override returns (string memory) {
         return "Embargo";
     }
 
-    function description() external view override returns (string memory) {
+    function description() external pure override returns (string memory) {
         return "Owner of the League can point to which nation the league is sanctioning";
     }
 

--- a/contracts/treaties/HandshakeDeal.sol
+++ b/contracts/treaties/HandshakeDeal.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {CurioTreaty} from "contracts/standards/CurioTreaty.sol";
 import {CurioERC20} from "contracts/standards/CurioERC20.sol";
+import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 import {Position} from "contracts/libraries/Types.sol";
 
 contract HandshakeDeal is CurioTreaty {
@@ -37,9 +38,14 @@ contract HandshakeDeal is CurioTreaty {
     mapping(uint256 => uint256[]) public nationIDToDealIDs;
     mapping(uint256 => Deal) public idToDeal;
 
-    constructor(address _diamond) CurioTreaty(_diamond) {
-        name = "Handshake Deal";
-        description = "Flexible handshake agreement between nations";
+    constructor(address _diamond) CurioTreaty(_diamond) {}
+
+    function name() external view override returns (string memory) {
+        return "Handshake Deal";
+    }
+
+    function description() external view override returns (string memory) {
+        return "Flexible handshake agreement between nations";
     }
 
     // ----------------------------------------------------------
@@ -62,6 +68,7 @@ contract HandshakeDeal is CurioTreaty {
                 _functionType == ApprovalFunctionType.approveUpgradeResource,
             "Handshake: Invalid function type"
         );
+        GetterFacet getter = GetterFacet(diamond);
         uint256 proposerID = getter.getEntityByAddress(msg.sender);
         dealCount++;
 
@@ -91,6 +98,7 @@ contract HandshakeDeal is CurioTreaty {
                 _functionType == ApprovalFunctionType.approveBattle,
             "Handshake: Invalid function type"
         );
+        GetterFacet getter = GetterFacet(diamond);
         uint256 proposerID = getter.getEntityByAddress(msg.sender);
         dealCount++;
 
@@ -119,6 +127,7 @@ contract HandshakeDeal is CurioTreaty {
                 _functionType == ApprovalFunctionType.approveMove,
             "Handshake: Invalid function type"
         );
+        GetterFacet getter = GetterFacet(diamond);
         uint256 proposerID = getter.getEntityByAddress(msg.sender);
         dealCount++;
 
@@ -136,6 +145,7 @@ contract HandshakeDeal is CurioTreaty {
     }
 
     function signDeal(uint256 _dealID) public onlySigner {
+        GetterFacet getter = GetterFacet(diamond);
         nationIDToDealIDs[getter.getEntityByAddress(msg.sender)].push(_dealID);
     }
 
@@ -149,6 +159,7 @@ contract HandshakeDeal is CurioTreaty {
 
     function treatyLeave() public override {
         // Can exit only after all time locks pass
+        GetterFacet getter = GetterFacet(diamond);
         uint256[] memory signedDealIDs = nationIDToDealIDs[getter.getEntityByAddress(msg.sender)];
         for (uint256 i = 0; i < signedDealIDs.length; i++) {
             Deal memory deal = idToDeal[signedDealIDs[i]];

--- a/contracts/treaties/HandshakeDeal.sol
+++ b/contracts/treaties/HandshakeDeal.sol
@@ -40,11 +40,11 @@ contract HandshakeDeal is CurioTreaty {
 
     constructor(address _diamond) CurioTreaty(_diamond) {}
 
-    function name() external view override returns (string memory) {
+    function name() external pure override returns (string memory) {
         return "Handshake Deal";
     }
 
-    function description() external view override returns (string memory) {
+    function description() external pure override returns (string memory) {
         return "Flexible handshake agreement between nations";
     }
 

--- a/contracts/treaties/MercenaryLeague.sol
+++ b/contracts/treaties/MercenaryLeague.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.13;
 
 import {CurioTreaty} from "contracts/standards/CurioTreaty.sol";
 import {CurioERC20} from "contracts/standards/CurioERC20.sol";
+import {AdminFacet} from "contracts/facets/AdminFacet.sol";
+import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 import {Position} from "contracts/libraries/Types.sol";
 import {Set} from "contracts/Set.sol";
 
@@ -27,11 +29,11 @@ contract MercenaryLeague is CurioTreaty {
         _;
     }
 
-    function name() external view override returns (string memory) {
+    function name() external pure override returns (string memory) {
         return "Mercenary League";
     }
 
-    function description() external view override returns (string memory) {
+    function description() external pure override returns (string memory) {
         return "A Military Alliance that allows drafting of armies.";
     }
 

--- a/contracts/treaties/MercenaryLeague.sol
+++ b/contracts/treaties/MercenaryLeague.sol
@@ -14,18 +14,25 @@ contract MercenaryLeague is CurioTreaty {
     uint256 public conscriptionDuration;
 
     constructor(address _diamond) CurioTreaty(_diamond) {
-        name = "Mercenary League";
-        description = "A Military Alliance that allows drafting of armies.";
-
+        GetterFacet getter = GetterFacet(diamond);
         goldToken = getter.getTokenContract("Gold");
         warCouncil = new Set();
         conscriptionDuration = 3600;
     }
 
     modifier onlyWarCouncil() {
+        GetterFacet getter = GetterFacet(diamond);
         uint256 callerID = getter.getEntityByAddress(msg.sender);
         require(warCouncil.includes(callerID), "Alliance: Only War Council can call");
         _;
+    }
+
+    function name() external view override returns (string memory) {
+        return "Mercenary League";
+    }
+
+    function description() external view override returns (string memory) {
+        return "A Military Alliance that allows drafting of armies.";
     }
 
     // ----------------------------------------------------------
@@ -46,6 +53,7 @@ contract MercenaryLeague is CurioTreaty {
     }
 
     function conscriptArmies(uint256 _nationID) public onlyWarCouncil {
+        GetterFacet getter = GetterFacet(diamond);
         require(memberToConscriptionFee[_nationID] > 0, "Alliance: Target must have a conscription fee set");
         require(getter.getNationTreatySignature(_nationID, getter.getEntityByAddress(address(this))) != 0, "Alliance: Target nation is not part of the alliance");
         require(memberConscriptionStartTime[getter.getEntityByAddress(msg.sender)] == 0, "Alliance: Target nation's armies have already been conscripted");
@@ -54,6 +62,7 @@ contract MercenaryLeague is CurioTreaty {
         address conscripterCapitalAddr = getter.getAddress(getter.getCapital(getter.getEntityByAddress(msg.sender)));
         address targetCapitalAddr = getter.getAddress(getter.getCapital(_nationID));
         goldToken.transferFrom(conscripterCapitalAddr, targetCapitalAddr, memberToConscriptionFee[_nationID]);
+        AdminFacet admin = AdminFacet(diamond);
         admin.adminDelegateGameFunction(_nationID, "Battle", getter.getEntityByAddress(msg.sender), 0, true);
         admin.adminDelegateGameFunction(_nationID, "Move", getter.getEntityByAddress(msg.sender), 0, true);
 
@@ -65,9 +74,11 @@ contract MercenaryLeague is CurioTreaty {
     // ----------------------------------------------------------
 
     function revokeArmies() public {
+        GetterFacet getter = GetterFacet(diamond);
         require(block.timestamp - memberConscriptionStartTime[getter.getEntityByAddress(msg.sender)] > conscriptionDuration, "Alliance: Nation's conscription hasn't expired yet");
 
         uint256 nationID = getter.getEntityByAddress(msg.sender);
+        AdminFacet admin = AdminFacet(diamond);
         admin.adminDelegateGameFunction(nationID, "Battle", getter.getEntityByAddress(msg.sender), 0, false);
         admin.adminDelegateGameFunction(nationID, "Move", getter.getEntityByAddress(msg.sender), 0, false);
 
@@ -75,18 +86,18 @@ contract MercenaryLeague is CurioTreaty {
         memberConscriptionStartTime[getter.getEntityByAddress(msg.sender)] = 0;
     }
 
-    function treatyLeave() public override {
-        // Check if nation has stayed in alliance for at least 10 seconds
-        uint256 nationID = getter.getEntityByAddress(msg.sender);
-        require(minimumStayCheck(nationID, 10), "Alliance: Nation must stay for at least 10 seconds");
+    function treatyLeave() public override minimumStay(10) {
+        GetterFacet getter = GetterFacet(diamond);
 
         // Check that nation has revoked conscripted armies (if any)
+        uint256 nationID = getter.getEntityByAddress(msg.sender);
         require(memberConscriptionStartTime[nationID] == 0, "Alliance: Nation must revoke conscripted armies before leaving");
 
         super.treatyLeave();
     }
 
     function setConscriptionFee(uint256 _fee) public onlySigner {
+        GetterFacet getter = GetterFacet(diamond);
         memberToConscriptionFee[getter.getEntityByAddress(msg.sender)] = _fee;
     }
 

--- a/contracts/treaties/NonAggressionPact.sol
+++ b/contracts/treaties/NonAggressionPact.sol
@@ -2,25 +2,34 @@
 pragma solidity ^0.8.13;
 
 import {CurioTreaty} from "contracts/standards/CurioTreaty.sol";
-import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 import {CurioERC20} from "contracts/standards/CurioERC20.sol";
+import {GetterFacet} from "contracts/facets/GetterFacet.sol";
+import {AdminFacet} from "contracts/facets/AdminFacet.sol";
 import {Position} from "contracts/libraries/Types.sol";
 
 contract NonAggressionPact is CurioTreaty {
-    constructor(address _diamond) CurioTreaty(_diamond) {
-        name = "Non-Aggression Pact";
-        description = "Member nations cannot battle armies or tiles of one another";
+    constructor(address _diamond) CurioTreaty(_diamond) {}
+
+    function name() external view override returns (string memory) {
+        return "Non-Aggression Pact";
+    }
+
+    function description() external view override returns (string memory) {
+        return "Member nations cannot battle armies or tiles of one another";
     }
 
     function addToWhitelist(uint256 _nationID) public onlyOwner {
+        AdminFacet admin = AdminFacet(diamond);
         admin.addToTreatyWhitelist(_nationID);
     }
 
     function removeFromWhitelist(uint256 _nationID) public onlyOwner {
+        AdminFacet admin = AdminFacet(diamond);
         admin.removeFromTreatyWhitelist(_nationID);
     }
 
     function removeMember(uint256 _nationID) public onlyOwner {
+        AdminFacet admin = AdminFacet(diamond);
         admin.removeFromTreatyWhitelist(_nationID); // need to be whitelisted again for joining
         admin.removeSigner(_nationID);
     }
@@ -29,12 +38,12 @@ contract NonAggressionPact is CurioTreaty {
         super.treatyJoin();
     }
 
-    function treatyLeave() public override {
-        // Check if nation has stayed in pact for at least 30 seconds
-        uint256 nationID = getter.getEntityByAddress(msg.sender);
-        require(minimumStayCheck(nationID, 30), "NAPact: Must stay for at least 30 seconds");
-
+    function treatyLeave() public override minimumStay(30) {
+        GetterFacet getter = GetterFacet(diamond);
+       
         // Remove nation from whitelist
+        uint256 nationID = getter.getEntityByAddress(msg.sender);
+        AdminFacet admin = AdminFacet(diamond);
         admin.removeFromTreatyWhitelist(nationID);
 
         super.treatyLeave();
@@ -45,6 +54,8 @@ contract NonAggressionPact is CurioTreaty {
     // ----------------------------------------------------------
 
     function approveBattle(uint256 _nationID, bytes memory _encodedParams) public view override returns (bool) {
+        GetterFacet getter = GetterFacet(diamond);
+       
         // Disapprove if target nation is part of pact
         (, , uint256 battleTargetID) = abi.decode(_encodedParams, (uint256, uint256, uint256));
         uint256 targetNationID = getter.getNation(battleTargetID);

--- a/contracts/treaties/NonAggressionPact.sol
+++ b/contracts/treaties/NonAggressionPact.sol
@@ -10,11 +10,11 @@ import {Position} from "contracts/libraries/Types.sol";
 contract NonAggressionPact is CurioTreaty {
     constructor(address _diamond) CurioTreaty(_diamond) {}
 
-    function name() external view override returns (string memory) {
+    function name() external pure override returns (string memory) {
         return "Non-Aggression Pact";
     }
 
-    function description() external view override returns (string memory) {
+    function description() external pure override returns (string memory) {
         return "Member nations cannot battle armies or tiles of one another";
     }
 

--- a/contracts/treaties/SimpleOTC.sol
+++ b/contracts/treaties/SimpleOTC.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {CurioTreaty} from "contracts/standards/CurioTreaty.sol";
 import {CurioERC20} from "contracts/standards/CurioERC20.sol";
+import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 
 struct Order {
     string sellTokenName;
@@ -18,10 +19,15 @@ contract SimpleOTC is CurioTreaty {
     Order public emptyOrder;
 
     constructor(address _diamond) CurioTreaty(_diamond) {
-        name = "Simple OTC Trading Agreement";
-        description = "OTC Trading between players";
-
         emptyOrder = Order({sellTokenName: "", sellAmount: 0, buyTokenName: "", buyAmount: 0, createdAt: 0});
+    }
+
+    function name() external view override returns (string memory) {
+        return "Simple OTC Trading Agreement";
+    }
+
+    function description() external view override returns (string memory) {
+        return "OTC Trading between players";
     }
 
     /**
@@ -65,6 +71,7 @@ contract SimpleOTC is CurioTreaty {
      * @param _seller address of the seller
      */
     function takeOrder(address _seller) public {
+        GetterFacet getter = GetterFacet(diamond);
         require(addressToOrder[_seller].sellAmount > 0, "OTC: Seller has no existing order");
 
         // Fetch token pair

--- a/contracts/treaties/SimpleOTC.sol
+++ b/contracts/treaties/SimpleOTC.sol
@@ -22,11 +22,11 @@ contract SimpleOTC is CurioTreaty {
         emptyOrder = Order({sellTokenName: "", sellAmount: 0, buyTokenName: "", buyAmount: 0, createdAt: 0});
     }
 
-    function name() external view override returns (string memory) {
+    function name() external pure override returns (string memory) {
         return "Simple OTC Trading Agreement";
     }
 
-    function description() external view override returns (string memory) {
+    function description() external pure override returns (string memory) {
         return "OTC Trading between players";
     }
 

--- a/contracts/treaties/TestTreaty.sol
+++ b/contracts/treaties/TestTreaty.sol
@@ -8,11 +8,11 @@ import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 contract TestTreaty is CurioTreaty {
     constructor(address _diamond) CurioTreaty(_diamond) {}
 
-    function name() external view override returns (string memory) {
+    function name() external pure override returns (string memory) {
         return "Test Treaty";
     }
 
-    function description() external view override returns (string memory) {
+    function description() external pure override returns (string memory) {
         return "Treaty for testing";
     }
 

--- a/contracts/treaties/TestTreaty.sol
+++ b/contracts/treaties/TestTreaty.sol
@@ -2,11 +2,18 @@
 pragma solidity ^0.8.13;
 
 import {CurioTreaty} from "contracts/standards/CurioTreaty.sol";
+import {GameFacet} from "contracts/facets/GameFacet.sol";
+import {GetterFacet} from "contracts/facets/GetterFacet.sol";
 
 contract TestTreaty is CurioTreaty {
-    constructor(address _diamond) CurioTreaty(_diamond) {
-        name = "Test Treaty";
-        description = "Treaty for testing";
+    constructor(address _diamond) CurioTreaty(_diamond) {}
+
+    function name() external view override returns (string memory) {
+        return "Test Treaty";
+    }
+
+    function description() external view override returns (string memory) {
+        return "Treaty for testing";
     }
 
     function treatyJoin() public override {
@@ -24,7 +31,10 @@ contract TestTreaty is CurioTreaty {
     }
 
     function treatyUpgradeCapital(uint256 _capitalID) public onlySigner {
+        GetterFacet getter = GetterFacet(diamond);
         uint256 nationID = getter.getEntityByAddress(msg.sender);
+
+        GameFacet game = GameFacet(diamond);
 
         game.delegateGameFunction(nationID, "UpgradeCapital", getter.getEntityByAddress(address(this)), _capitalID, true);
         game.delegateGameFunction(nationID, "HarvestResourcesFromCapital", getter.getEntityByAddress(address(this)), _capitalID, true);

--- a/test/Treaty.t.sol
+++ b/test/Treaty.t.sol
@@ -278,7 +278,7 @@ contract TreatyTest is Test, DiamondDeployTest {
 
         // Nation 2 fails to leave alliance
         vm.startPrank(player2);
-        vm.expectRevert("Alliance: Nation must stay for at least 10 seconds");
+        vm.expectRevert("Have not stayed for minimum duration");
         alliance.treatyLeave();
         vm.stopPrank();
 


### PR DESCRIPTION
- Remove duplicated storage of admin, game, and getter facets
- Remove unnecessary storage of name and description
- Make minimumStayCheck a modifier